### PR TITLE
Handle 204 responses

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm64v8/php:8.1-fpm
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y curl zip unzip libonig-dev
 
 # Clear cache
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -39,5 +39,3 @@ RUN mkdir -p /var/www/app && \
 
 # Set working directory
 WORKDIR /var/www/app
-
-USER ubuntu

--- a/src/Traits/Batches.php
+++ b/src/Traits/Batches.php
@@ -87,7 +87,7 @@ trait Batches
     public function deleteBatchById(
         string $batchId,
         array|ShipEngineConfig|null $config = null,
-    ): array|string {
+    ): array|string|null {
         return ShipEngineClient::delete(
             "batches/$batchId",
             $this->config->merge($config),
@@ -126,7 +126,7 @@ trait Batches
         string $batchId,
         array $batch,
         array|ShipEngineConfig|null $config = null,
-    ): array {
+    ): array|null {
         return ShipEngineClient::put(
             "batches/$batchId",
             $this->config->merge($config),
@@ -143,7 +143,7 @@ trait Batches
         string $batchId,
         array $payload,
         array|ShipEngineConfig|null $config = null,
-    ): array {
+    ): array|null {
         return ShipEngineClient::post(
             "batches/$batchId/add",
             $this->config->merge($config),
@@ -185,7 +185,7 @@ trait Batches
         string $batchId,
         array $payload = [],
         array|ShipEngineConfig|null $config = null,
-    ): array {
+    ): array|null {
         return ShipEngineClient::post(
             "batches/$batchId/process/labels",
             $this->config->merge($config),
@@ -202,7 +202,7 @@ trait Batches
         string $batchId,
         array $payload = [],
         array|ShipEngineConfig|null $config = null,
-    ): array {
+    ): array|null {
         return ShipEngineClient::post(
             "batches/$batchId/remove",
             $this->config->merge($config),

--- a/src/Traits/CarrierAccounts.php
+++ b/src/Traits/CarrierAccounts.php
@@ -42,7 +42,7 @@ trait CarrierAccounts
         string $carrierName,
         string $carrierId,
         array|ShipEngineConfig|null $config = null,
-    ): array {
+    ): array|null {
         return ShipEngineClient::delete(
             "connections/carriers/$carrierName/$carrierId",
             $this->config->merge($config),
@@ -50,7 +50,7 @@ trait CarrierAccounts
     }
 
     /**
-     * @see https://shipengine.github.io/shipengine-openapi/#operation/disconnect_carrier
+     * @see https://shipengine.github.io/shipengine-openapi/#operation/get_carrier_settings
      *
      * @throws Exception|GuzzleException
      */
@@ -80,7 +80,7 @@ trait CarrierAccounts
     }
 
     /**
-     * @see https://shipengine.github.io/shipengine-openapi/#operation/disconnect_carrier
+     * @see https://shipengine.github.io/shipengine-openapi/#operation/update_carrier_settings
      *
      * @throws Exception|GuzzleException
      */

--- a/src/Traits/PackageTypes.php
+++ b/src/Traits/PackageTypes.php
@@ -87,7 +87,7 @@ trait PackageTypes
         string $packageTypeId,
         array $payload,
         array|ShipEngineConfig|null $config = null,
-    ): array|string {
+    ): array|string|null {
         return ShipEngineClient::put(
             "packages/$packageTypeId",
             $config,
@@ -103,7 +103,7 @@ trait PackageTypes
     public function deleteCustomPackageTypeById(
         string $packageTypeId,
         array|ShipEngineConfig|null $config = null,
-    ): array|string {
+    ): array|string|null {
         return ShipEngineClient::delete(
             "packages/$packageTypeId",
             $config,

--- a/src/Traits/Shipments.php
+++ b/src/Traits/Shipments.php
@@ -175,7 +175,7 @@ trait Shipments
      * @param string $id
      * @param array|ShipEngineConfig|null $config
      *
-     * @return array
+     * @return array|null
      *
      * @throws GuzzleException|Exception
      *
@@ -184,7 +184,7 @@ trait Shipments
     public function cancelShipment(
         string $id,
         array|ShipEngineConfig $config = null,
-    ) : array {
+    ) : array|null {
         return ShipEngineClient::put(
             "shipments/$id/cancel",
             $this->config->merge($config),
@@ -241,7 +241,7 @@ trait Shipments
      * @param string $tag_name
      * @param array|ShipEngineConfig|null $config
      *
-     * @return array
+     * @return array|null
      *
      * @throws GuzzleException|Exception
      *
@@ -251,7 +251,7 @@ trait Shipments
         string $id,
         string $tag_name,
         array|ShipEngineConfig $config = null,
-    ) : array {
+    ) : array|null {
         return ShipEngineClient::delete(
             "shipments/$id/tags/$tag_name",
             $this->config->merge($config),

--- a/src/Traits/Tags.php
+++ b/src/Traits/Tags.php
@@ -61,7 +61,7 @@ trait Tags
     public function deleteTag(
         string $tag_name,
         array|ShipEngineConfig $config = null,
-    ) : array {
+    ) : array|null {
         return ShipEngineClient::delete(
             "tags/$tag_name",
             $this->config->merge($config),
@@ -77,7 +77,7 @@ trait Tags
         string $tag_name,
         string $new_tag_name,
         array|ShipEngineConfig $config = null,
-    ) : array {
+    ) : array|null {
         return ShipEngineClient::put(
             "tags/$tag_name/$new_tag_name",
             $this->config->merge($config),

--- a/src/Traits/Tracking.php
+++ b/src/Traits/Tracking.php
@@ -42,7 +42,7 @@ trait Tracking
         string $carrier_code,
         string $tracking_number,
         array|ShipEngineConfig $config = null,
-    ) : array {
+    ) : array|null {
         return ShipEngineClient::post(
             "tracking/start?carrier_code=$carrier_code&tracking_number=$tracking_number",
             $this->config->merge($config),
@@ -58,7 +58,7 @@ trait Tracking
         string $carrier_code,
         string $tracking_number,
         array|ShipEngineConfig $config = null,
-    ) : array {
+    ) : array|null {
         return ShipEngineClient::post(
             "tracking/stop?carrier_code=$carrier_code&tracking_number=$tracking_number",
             $this->config->merge($config),

--- a/src/Traits/Warehouse.php
+++ b/src/Traits/Warehouse.php
@@ -96,7 +96,7 @@ trait Warehouse
         array $origin_address,
         array $return_address = [],
         array|ShipEngineConfig $config = null,
-    ) : array {
+    ) : array|null {
         $payload = [
             'name' => $name,
             'origin_address' => $origin_address,
@@ -120,7 +120,7 @@ trait Warehouse
     public function deleteWarehouseById(
         string $warehouse_id,
         array|ShipEngineConfig $config = null,
-    ) : array {
+    ) : array|null {
         return ShipEngineClient::delete(
             "warehouses/{$warehouse_id}",
             $this->config->merge($config),


### PR DESCRIPTION
## Description

Updated request to check for 204 and respond with null vs array. Updated all endpoint calls that can be 204 to allow null returns

Fix for issue #8 

## Release Notes

Handling 204 responses properly by returning null

## Types of changes

- [X] Bugfix
- [ ] New feature
- [X] Chore (mundane code change)
- [ ] Maintenance (clean up)

## Checklist

- [ ] Unit tests pass locally
- [ ] Added tests to code that was updated or edited
- [ ] Updated/added documentation
