### PR TITLE
ShipEngineClient: Handle all exceptions when making requests

### DIFF
--- a/src/ShipEngineClient.php
+++ b/src/ShipEngineClient.php
@@ -7,7 +7,6 @@ use BluefynInternational\ShipEngine\Message\ShipEngineException;
 use BluefynInternational\ShipEngine\Models\RequestLog;
 use Exception;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\Response;

--- a/src/ShipEngineClient.php
+++ b/src/ShipEngineClient.php
@@ -5,11 +5,13 @@ namespace BluefynInternational\ShipEngine;
 use BluefynInternational\ShipEngine\Message\RateLimitExceededException;
 use BluefynInternational\ShipEngine\Message\ShipEngineException;
 use BluefynInternational\ShipEngine\Models\RequestLog;
+use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\Response;
+use Throwable;
 
 class ShipEngineClient
 {
@@ -184,7 +186,7 @@ class ShipEngineClient
                 $request,
                 ['timeout' => $config->timeout->s, 'http_errors' => false]
             );
-        } catch (ClientException $err) {
+        } catch (Exception|Throwable  $err) {
             if (config('shipengine.track_requests')) {
                 $requestLog->exception = substr($err->getMessage(), 0, 255);
                 $requestLog->save();

--- a/src/ShipEngineClient.php
+++ b/src/ShipEngineClient.php
@@ -146,7 +146,7 @@ class ShipEngineClient
      *
      * @return array|null
      *
-     * @throws GuzzleException
+     * @throws GuzzleException|ShipEngineException
      */
     private static function sendRequest(
         string $method,


### PR DESCRIPTION
## Description

Handle all exceptions when making requests. This will allow the request logger to record any details if it's enabled and allows the function to throw a ShipEngineException that wraps others

## Release Notes

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Chore (mundane code change)
- [ ] Maintenance (clean up)

## Checklist

- [x] Unit tests pass locally
- [ ] Added tests to code that was updated or edited
- [ ] Updated/added documentation
